### PR TITLE
chore: bump MSRV to 1.92, ignore dtolnay/rust-toolchain in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,5 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    ignore:
+      - dependency-name: "dtolnay/rust-toolchain"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "supplicant-rs"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.75"
+rust-version = "1.92"
 license = "Apache-2.0"
 description = "Pure Rust WPA supplicant: WPA2/WPA3, EAP, 802.1X. Memory-safe replacement for wpa_supplicant."
 repository = "https://github.com/structured-world/supplicant-rs"


### PR DESCRIPTION
## Summary
- Bump `rust-version` in Cargo.toml: 1.75 → 1.92
- Exclude `dtolnay/rust-toolchain` from dependabot github-actions updates

Closes #3